### PR TITLE
Moved feedback section to just before </body>

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -15,12 +15,12 @@
 
   <body class="<%= page_classes %>">
     <div id="top">
-      <div id="wip">This is a work in progress: <a href="https://docs.google.com/a/coopdigital.co.uk/forms/d/e/1FAIpQLSeD4Fbz0-RI8ltn_cuP7Xrcce4gr5hAEn0saGV_ELoAvL3oQw/viewform?usp=sf_link" target="_blank">Give feedback</a></div>
       <header id="topnav">
         <%= link_to 'Digital Product Research', 'index.html' %><span>We’re a team at Co-op Digital and this is the archive of our experiments</span>
         <%= link_to 'About', 'about' %>
       </header>
     </div>
     <%= yield %>
+    <div id="wip">This is a work in progress: <a href="https://docs.google.com/a/coopdigital.co.uk/forms/d/e/1FAIpQLSeD4Fbz0-RI8ltn_cuP7Xrcce4gr5hAEn0saGV_ELoAvL3oQw/viewform?usp=sf_link" target="_blank">Give feedback</a></div>
   </body>
 </html>


### PR DESCRIPTION
I’ve moved the div section to just before /body but I’m not sure how to test this. The feedback bar still shows and the link still works, is there anything else I should check?