### PR TITLE
Add metadata to articles

### DIFF
--- a/source/after-work.html.erb
+++ b/source/after-work.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Life after work | Digital product research
+desc: We spoke to 5 people who had recently stopped working and 5 people who work with older people. This was in preparation for a design sprint about living well.
+auth:
 ---
 
 <%= partial('partials/experiment/life-after-work') %>

--- a/source/connected.html.erb
+++ b/source/connected.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Everything is connected | Digital product research
+desc: Could we show people the potential risks of using devices that connect to the internet? We built a prototype home network analysis tool to find out.
+auth:
 ---
 
 <%= partial('partials/experiment/connected-devices') %>

--- a/source/financial-freedom.html.erb
+++ b/source/financial-freedom.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Financial freedom | Digital product research
+desc: Could we help people in their 20s understand compound interest, to help them save for their long term future? We built a prototype savings tool to find out.
+auth:
 ---
 
 <%= partial('partials/experiment/financial-freedom') %>

--- a/source/group-trust.html.erb
+++ b/source/group-trust.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Protecting your stuff | Digital product research
+desc: Could we create an insurance model based on trust and where it's OK to claim? We built a prototype group insurance scheme to find out.
+auth:
 ---
 
 <%= partial('partials/experiment/group-trust') %>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -7,7 +7,10 @@
 
     <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:300,500|Playfair+Display|Overpass:400,700|Nunito:400,700|Arimo:400,700" rel="stylesheet">
 
-    <title><%= current_page.data.title || "Digital Product Research" %></title>
+    <title><%= current_page.data.title || "Digital product research" %></title>
+    <meta name="description"><%= current_page.data.desc || "Digital product research" %></meta>
+    <meta name="author"><%= current_page.data.auth || "Digital product research team at Co-op Digital" %></meta>
+
 
     <%= stylesheet_link_tag :site %>
     <%= javascript_include_tag :all %>

--- a/source/locally.html.erb
+++ b/source/locally.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Keeping money local | Digital product research
+desc: Could we help local independent shop keepers work together to increase local spending? We built a prototype local shared loyalty scheme to find out.
+auth:
 ---
 
 <%= partial('partials/experiment/locally') %>

--- a/source/shared-energy.html.erb
+++ b/source/shared-energy.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Cheaper, greener energy | Digital product research
+desc: Do people want to buy renewable energy off their neighbours? We brought together a group of people as a prototype energy trading community to find out.
+auth:
 ---
 
 <%= partial('partials/experiment/shared-energy') %>

--- a/source/terms.html.erb
+++ b/source/terms.html.erb
@@ -1,5 +1,7 @@
 ---
 title: Terms and reviewers | Digital product research
+desc: Could we get journalists to talk about privacy when reviewing connected devices? We built a prototype terms and conditions analysis community to find out.
+auth:
 ---
 
 <%= partial('partials/experiment/terms-reviewers') %>


### PR DESCRIPTION
This was to fix an issue picked up in the accessibility test - meta descriptions were missing from pages
- Add meta descriptions to all articles
- Update layout file with meta description and meta author